### PR TITLE
install service also as script to make it user-callable

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,6 +4,9 @@
    	<import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.service" library="default.py" start="login"></extension>
+  <extension point="xbmc.python.script" library="scan_exec.py">
+    <provides>executable</provides>
+  </extension>  
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
     <language></language>

--- a/scan_exec.py
+++ b/scan_exec.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+# -*- coding: utf8 -*-
+
+import xbmc, xbmcaddon
+
+from os.path import join
+from pprint import pformat
+
+# Script constants
+__settings__ = xbmcaddon.Addon()
+__homepath__ = __settings__.getAddonInfo('path').decode('utf-8')
+
+def scan_exec():
+    xbmc.log("scan_exec.py : Starting MyPicsDB Library Update", xbmc.LOGNOTICE)
+    script = u"%s,--refresh"% join( __homepath__, u"..", u"plugin.image.mypicsdb", u"scanpath.py")
+    xbmc.executebuiltin('XBMC.RunScript(%s)'%script.encode('utf-8'))                    
+
+if __name__=="__main__":
+    try:
+	    scan_exec()
+    except Exception, e:
+        xbmc.log(pformat(e))


### PR DESCRIPTION
This will install the "update service" as also an "executable" and make it possible to invoke from the outside typically over JSON-RPC interface like this PowerShell example ;

`invoke-webrequest -uri 192.168.0.10/jsonrpc?request='{"jsonrpc":"2.0","id":1,"method":"Addons.ExecuteAddon","params":{"addonid" : "script.service.mypicsdb"}}'`

This gives greater flexibility in scheduling library updates than simply running at specific times. In my use-case I have a file-change-notification-service on my NAS that kicks in and triggers a library update as soon as there is something added.
